### PR TITLE
Update hi_by_trackId.R

### DIFF
--- a/R/hi_by_trackId.R
+++ b/R/hi_by_trackId.R
@@ -76,7 +76,6 @@ hi_by_trackId <- function(move,fun="hi_distance",...){
     tdiff <- round(t2-t1,digits=1)
     print(paste0('Processed: ',id,'. Processing Time: ',tdiff,' s'))
   }
-  output <- move2::mt_stack(output)  
   return(output)
 }
 


### PR DESCRIPTION
Removed mt_stack so sf object is returned instead of move2. Not all outputs were compatible with mt_stack, throwing critical error on failure. 